### PR TITLE
Select correct hxml file (based on project prefs)

### DIFF
--- a/haxe4e-plugin/src/main/java/org/haxe4e/project/HaxeProjectImportConfigurator.java
+++ b/haxe4e-plugin/src/main/java/org/haxe4e/project/HaxeProjectImportConfigurator.java
@@ -21,7 +21,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.ui.wizards.datatransfer.ProjectConfigurator;
-import org.haxe4e.Constants;
 import org.haxe4e.util.LOG;
 
 import net.sf.jstuff.core.collection.Sets;
@@ -47,10 +46,9 @@ public final class HaxeProjectImportConfigurator implements ProjectConfigurator 
 
             @Override
             public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
-               switch (file.getFileName().toString()) {
-                  case Constants.DEFAULT_HAXE_BUILD_FILE:
-                  case "haxelib.json":
-                     haxeProjects.add(file.getParent().toFile());
+               final String fileName = file.getFileName().toString();
+               if (fileName.endsWith(".hxml") || "haxelib.json".equals(fileName)) {
+                  haxeProjects.add(file.getParent().toFile());
                }
                return FileVisitResult.CONTINUE;
             }

--- a/haxe4e-plugin/src/main/java/org/haxe4e/widget/HaxeBuildFileSelectionGroup.java
+++ b/haxe4e-plugin/src/main/java/org/haxe4e/widget/HaxeBuildFileSelectionGroup.java
@@ -25,6 +25,7 @@ import org.eclipse.ui.dialogs.ElementListSelectionDialog;
 import org.haxe4e.Constants;
 import org.haxe4e.Haxe4EPlugin;
 import org.haxe4e.localization.Messages;
+import org.haxe4e.prefs.HaxeProjectPreference;
 import org.haxe4e.util.LOG;
 import org.haxe4e.util.ui.Buttons;
 import org.haxe4e.util.ui.GridDatas;
@@ -65,7 +66,13 @@ public class HaxeBuildFileSelectionGroup extends Composite {
       btnBrowseBuildFile.setEnabled(false);
       Buttons.onSelected(btnBrowseBuildFile, this::onBuildFileButton);
 
-      project.subscribe(p -> btnBrowseBuildFile.setEnabled(p != null));
+      project.subscribe(p -> {
+         btnBrowseBuildFile.setEnabled(p != null);
+         if (p != null) {
+            final HaxeProjectPreference prefs = new HaxeProjectPreference(p);
+            buildFile.set(prefs.getHaxeBuildFile());
+         }
+      });
    }
 
    private AbstractElementListSelectionDialog createSelectBuildFileDialog(final Shell shell, final IProject project,


### PR DESCRIPTION
* when importing a project any .hxml file is considered valid (instead of just build.hxml)
* when creating a new run config, after selecting the project .hxml from prefs is used

Fixes https://github.com/haxe4e/haxe4e/issues/6
Partially fixes https://github.com/haxe4e/haxe4e/issues/5